### PR TITLE
trying to fix ref to raw.stripe by changing it to `dbt_tutorial`. whi…

### DIFF
--- a/models/staging/stripe/stg_payments.sql
+++ b/models/staging/stripe/stg_payments.sql
@@ -6,4 +6,4 @@ select
     amount / 100 as amount,
     created as created_at
 
-from raw.stripe.payment
+from `dbt_tutorial`.stripe.payment


### PR DESCRIPTION
…ch matches with stg_customers and other jaffle_shop db designations